### PR TITLE
fix ExcelTableConverter - SetValue

### DIFF
--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
@@ -92,7 +92,7 @@
                     break;
 
                 default:
-                    cell.Value = content.ValueObject;
+                    cell.SetValue(content.ValueObject);
                     break;
             }
         }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Directory.Build.Props
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Directory.Build.Props
@@ -3,5 +3,6 @@
 
     <PropertyGroup>
         <Version>1.0.2</Version>
+        <PackageReleaseNotes>Fix SetValue for string type values, without format auto-detection.</PackageReleaseNotes>
     </PropertyGroup>
 </Project>

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Directory.Build.Props
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Directory.Build.Props
@@ -2,6 +2,6 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <PropertyGroup>
-        <Version>1.0.1</Version>
+        <Version>1.0.2</Version>
     </PropertyGroup>
 </Project>

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Directory.Build.Props
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Directory.Build.Props
@@ -2,7 +2,7 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <PropertyGroup>
-        <Version>1.0.2</Version>
+        <Version>1.0.2-dev01</Version>
         <PackageReleaseNotes>Fix SetValue for string type values, without format auto-detection.</PackageReleaseNotes>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Установка значения через свойство Value - пытается определить формат ячейки. И в некоторых случаях, неверно преобразует строку в дату.  
SetValue - не определяет формат значения.  
Например - такое строковое значение: 5-6, преобразуется в дату 05.06.2022.
![image](https://user-images.githubusercontent.com/1446481/204714565-c58c8900-b3ed-4116-84f8-820e88171324.png)
