### PR TITLE
PIKT-273 Доработка плагина "Ведомость спецификаций" до версии 1.5.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.300",
+    "version": "6.0.411",
     "rollForward": "latestPatch"
   }
 }

--- a/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
@@ -1,5 +1,7 @@
 ﻿namespace RxBim.Tools.Revit.Abstractions
 {
+    using System;
+    using System.Collections.Generic;
     using Autodesk.Revit.DB;
 
     /// <summary>
@@ -58,5 +60,12 @@
         /// Вернуть выделение сохраненным ранее элементам
         /// </summary>
         void SetBackSelectedElements();
+
+        /// <summary>
+        /// Получить выделенный элемент по фильтру
+        /// </summary>
+        /// <param name="filterElement">фильтр</param>
+        /// <returns></returns>
+        IEnumerable<Element> GetSelectedElementsByFilter(Func<Element, bool>? filterElement = null);
     }
 }

--- a/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
@@ -66,6 +66,6 @@
         /// </summary>
         /// <param name="filterElement">фильтр</param>
         /// <returns></returns>
-        IEnumerable<Element> GetSelectedElementsByFilter(Func<Element, bool>? filterElement = null);
+        List<Element> GetSelectedElementsByFilter(Func<Element, bool>? filterElement = null);
     }
 }

--- a/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
@@ -62,10 +62,9 @@
         void SetBackSelectedElements();
 
         /// <summary>
-        /// Получить выделенные элементы по фильтру
+        /// Возвращает выделенные элементы по фильтру
         /// </summary>
         /// <param name="predicate">предикат</param>
-        /// <returns></returns>
         List<Element> GetSelectedElements(Predicate<Element>? predicate = null);
     }
 }

--- a/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
@@ -64,8 +64,8 @@
         /// <summary>
         /// Получить выделенные элементы по фильтру
         /// </summary>
-        /// <param name="filterElement">фильтр</param>
+        /// <param name="predicate">предикат</param>
         /// <returns></returns>
-        List<Element> GetSelectedElements(Predicate<Element>? filterElement = null);
+        List<Element> GetSelectedElements(Predicate<Element>? predicate = null);
     }
 }

--- a/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
@@ -62,10 +62,10 @@
         void SetBackSelectedElements();
 
         /// <summary>
-        /// Получить выделенный элемент по фильтру
+        /// Получить выделенные элементы по фильтру
         /// </summary>
         /// <param name="filterElement">фильтр</param>
         /// <returns></returns>
-        List<Element> GetSelectedElementsByFilter(Func<Element, bool>? filterElement = null);
+        List<Element> GetSelectedElements(Func<Element, bool>? filterElement = null);
     }
 }

--- a/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Abstractions/IScopedElementsCollector.cs
@@ -66,6 +66,6 @@
         /// </summary>
         /// <param name="filterElement">фильтр</param>
         /// <returns></returns>
-        List<Element> GetSelectedElements(Func<Element, bool>? filterElement = null);
+        List<Element> GetSelectedElements(Predicate<Element>? filterElement = null);
     }
 }

--- a/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
@@ -174,15 +174,13 @@
             var uiDoc = _uiApplication.ActiveUIDocument;
             var selectedElementIds = uiDoc.Selection.GetElementIds();
 
-            List<Element> pickElements;
-
             predicate ??= _ => true;
-            pickElements = selectedElementIds.Select(elementId => uiDoc.Document.GetElement(elementId))
+            var selectedElements = selectedElementIds.Select(elementId => uiDoc.Document.GetElement(elementId))
                 .Where(element => predicate(element)).ToList();
 
-            UpdateSavedElementsForSelection(uiDoc.Document.Title, pickElements);
+            UpdateSavedElementsForSelection(uiDoc.Document.Title, selectedElements);
 
-            return pickElements;
+            return selectedElements;
         }
 
         /// <inheritdoc />

--- a/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
@@ -174,6 +174,24 @@
             }
         }
 
+        /// <inheritdoc/>
+        public IEnumerable<Element> GetSelectedElementsByFilter(Func<Element, bool>? filterElement = null)
+        {
+            var uiDoc = _uiApplication.ActiveUIDocument;
+
+            var selectedElementIds = uiDoc.Selection.GetElementIds();
+            if (selectedElementIds.Any() && filterElement != null)
+            {
+                foreach (var elementId in selectedElementIds)
+                {
+                    if (filterElement.Invoke(uiDoc.Document.GetElement(elementId)))
+                    {
+                        yield return uiDoc.Document.GetElement(elementId);
+                    }
+                }
+            }
+        }
+
         /// <inheritdoc />
         public LinkedElement? PickLinkedElement(Func<Element, bool>? filterElement = null, string statusPrompt = "")
         {

--- a/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
@@ -175,21 +175,33 @@
         }
 
         /// <inheritdoc/>
-        public IEnumerable<Element> GetSelectedElementsByFilter(Func<Element, bool>? filterElement = null)
+        public List<Element> GetSelectedElementsByFilter(Func<Element, bool>? filterElement = null)
         {
             var uiDoc = _uiApplication.ActiveUIDocument;
+
+            var pickElements = new List<Element>();
 
             var selectedElementIds = uiDoc.Selection.GetElementIds();
             if (selectedElementIds.Any() && filterElement != null)
             {
                 foreach (var elementId in selectedElementIds)
                 {
-                    if (filterElement.Invoke(uiDoc.Document.GetElement(elementId)))
+                    var element = uiDoc.Document.GetElement(elementId);
+                    if (filterElement.Invoke(element))
                     {
-                        yield return uiDoc.Document.GetElement(elementId);
+                        pickElements.Add(element);
+                        ////yield return uiDoc.Document.GetElement(elementId);
                     }
                 }
             }
+
+            // Обновляем сохраненные элементы для выбора
+            if (_selectedElementsIds.ContainsKey(uiDoc.Document.Title))
+                _selectedElementsIds[uiDoc.Document.Title] = pickElements.Select(e => e.Id).ToList();
+            else
+                _selectedElementsIds.Add(uiDoc.Document.Title, pickElements.Select(e => e.Id).ToList());
+
+            return pickElements;
         }
 
         /// <inheritdoc />

--- a/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
@@ -169,22 +169,16 @@
         }
 
         /// <inheritdoc/>
-        public List<Element> GetSelectedElements(Func<Element, bool>? filterElement = null)
+        public List<Element> GetSelectedElements(Predicate<Element>? filterElement = null)
         {
             var uiDoc = _uiApplication.ActiveUIDocument;
             var selectedElementIds = uiDoc.Selection.GetElementIds();
 
             List<Element> pickElements;
 
-            if (filterElement == null)
-            {
-                pickElements = selectedElementIds.Select(elementId => uiDoc.Document.GetElement(elementId)).ToList();
-            }
-            else
-            {
-                pickElements = selectedElementIds.Select(elementId => uiDoc.Document.GetElement(elementId))
-                    .Where(element => filterElement.Invoke(element)).ToList();
-            }
+            filterElement ??= _ => true;
+            pickElements = selectedElementIds.Select(elementId => uiDoc.Document.GetElement(elementId))
+                .Where(element => filterElement(element)).ToList();
 
             UpdateSavedElementsForSelection(uiDoc.Document.Title, pickElements);
 

--- a/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
@@ -174,7 +174,7 @@
             var uiDoc = _uiApplication.ActiveUIDocument;
             var selectedElementIds = uiDoc.Selection.GetElementIds();
 
-            var pickElements = new List<Element>();
+            List<Element> pickElements;
 
             if (filterElement == null)
             {

--- a/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
+++ b/src/Revit/RxBim.Tools.Revit/Collectors/ScopedElementsCollector.cs
@@ -169,16 +169,16 @@
         }
 
         /// <inheritdoc/>
-        public List<Element> GetSelectedElements(Predicate<Element>? filterElement = null)
+        public List<Element> GetSelectedElements(Predicate<Element>? predicate = null)
         {
             var uiDoc = _uiApplication.ActiveUIDocument;
             var selectedElementIds = uiDoc.Selection.GetElementIds();
 
             List<Element> pickElements;
 
-            filterElement ??= _ => true;
+            predicate ??= _ => true;
             pickElements = selectedElementIds.Select(elementId => uiDoc.Document.GetElement(elementId))
-                .Where(element => filterElement(element)).ToList();
+                .Where(element => predicate(element)).ToList();
 
             UpdateSavedElementsForSelection(uiDoc.Document.Title, pickElements);
 

--- a/src/Revit/RxBim.Tools.Revit/Directory.Build.Props
+++ b/src/Revit/RxBim.Tools.Revit/Directory.Build.Props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
     <PropertyGroup>
-        <ApiVersion>3.8</ApiVersion>
+        <ApiVersion>3.9-dev001</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/src/Revit/RxBim.Tools.Revit/README.md
+++ b/src/Revit/RxBim.Tools.Revit/README.md
@@ -1,0 +1,4 @@
+## About RxBim.Tools.Revit
+
+## 3.9
+Добавлен метод для получения выделенных элементов по фильтру в IScopedElementsCollector

--- a/src/Revit/RxBim.Tools.Revit/RxBim.Tools.Revit.csproj
+++ b/src/Revit/RxBim.Tools.Revit/RxBim.Tools.Revit.csproj
@@ -4,6 +4,7 @@
         <UseWPF>true</UseWPF>
         <UseDi>true</UseDi>
         <Optimize>false</Optimize>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -36,6 +37,10 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>RxBim.Tools.Revit.Tests</_Parameter1>
         </AssemblyAttribute>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="" />
     </ItemGroup>
 
 </Project>

--- a/src/Revit/RxBim.Tools.TableBuilder.Revit/Directory.Build.Props
+++ b/src/Revit/RxBim.Tools.TableBuilder.Revit/Directory.Build.Props
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-        <ApiVersion>1.9</ApiVersion>
+        <ApiVersion>1.10-dev001</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/src/Revit/RxBim.Tools.TableBuilder.Revit/README.md
+++ b/src/Revit/RxBim.Tools.TableBuilder.Revit/README.md
@@ -1,0 +1,4 @@
+## About RxBim.Tools.TableBuilder
+
+## 1.10
+Обновление зависимостей

--- a/src/Revit/RxBim.Tools.TableBuilder.Revit/RxBim.Tools.TableBuilder.Revit.csproj
+++ b/src/Revit/RxBim.Tools.TableBuilder.Revit/RxBim.Tools.TableBuilder.Revit.csproj
@@ -18,6 +18,11 @@
         <Description>RxBim Revit Table</Description>
         <PackageId>RxBim.Tools.TableBuilder.Revit</PackageId>
         <PackageReleaseNotes>$(ReleaseNotes)</PackageReleaseNotes>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="" />
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Добавлен метод для получения выделенных элементов в IScopedElementsCollector, т.к. в плагине нет доступа к активному листу и в дальнейшем нужно чтобы выделенный элемент сохранялся в _selectedElementsIds

Используется в рамках задачи PIKT-273 Доработка плагина "Ведомость спецификаций" до версии 1.5.0
Jira: https://jira.pik.ru/browse/PIKT-273