### PR TITLE
изменил регистрацию ScopedElementsCollector

### DIFF
--- a/RxBim.Tools.sln
+++ b/RxBim.Tools.sln
@@ -25,7 +25,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionFolder", "SolutionF
 		stylecop.ruleset = stylecop.ruleset
 		stylecopTests.ruleset = stylecopTests.ruleset
 		Directory.Build.Props = Directory.Build.Props
-		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "build\_build.csproj", "{E2EC9FDA-2F0E-4BD1-8F63-3787605ED60C}"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.300",
-    "rollForward": "latestPatch"
-  }
-}

--- a/src/Revit/RxBim.Tools.Revit/ContainerExtensions.cs
+++ b/src/Revit/RxBim.Tools.Revit/ContainerExtensions.cs
@@ -23,8 +23,11 @@
                 .AddSingleton<ISheetsCollector, SheetsCollector>()
                 .AddSingleton<IElementsDisplay, ElementsDisplayService>()
                 .AddSingleton<ISharedParameterService, SharedParameterService>()
-                .AddSingleton<IElementsCollector, ScopedElementsCollector>()
-                .AddSingleton<IScopedElementsCollector, ScopedElementsCollector>()
+                //// for single instance of ScopedElementsCollector from IServiceProvider
+                //// for IScopedElementsCollector and IElementsCollector.
+                .AddSingleton<ScopedElementsCollector>()
+                .AddSingleton<IElementsCollector>(container.GetService<ScopedElementsCollector>)
+                .AddSingleton<IScopedElementsCollector>(container.GetService<ScopedElementsCollector>)
                 .AddSingleton<ITransactionContextService<IDocumentWrapper>, DocumentContextService>()
                 .AddSingleton<ITransactionContextService<ITransactionContextWrapper>, DocumentContextService>()
                 .AddTransactionServices<RevitTransactionFactory>()

--- a/src/Revit/RxBim.Tools.Revit/ContainerExtensions.cs
+++ b/src/Revit/RxBim.Tools.Revit/ContainerExtensions.cs
@@ -23,8 +23,6 @@
                 .AddSingleton<ISheetsCollector, SheetsCollector>()
                 .AddSingleton<IElementsDisplay, ElementsDisplayService>()
                 .AddSingleton<ISharedParameterService, SharedParameterService>()
-                //// for single instance of ScopedElementsCollector from IServiceProvider
-                //// for IScopedElementsCollector and IElementsCollector.
                 .AddSingleton<ScopedElementsCollector>()
                 .AddSingleton<IElementsCollector>(container.GetService<ScopedElementsCollector>)
                 .AddSingleton<IScopedElementsCollector>(container.GetService<ScopedElementsCollector>)

--- a/src/Revit/RxBim.Tools.Revit/Directory.Build.Props
+++ b/src/Revit/RxBim.Tools.Revit/Directory.Build.Props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <ApiVersion>3.9-dev003</ApiVersion>
+        <ApiVersion>3.9-dev004</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>


### PR DESCRIPTION
в ScopedElementsCollector сбрасывается выделение в интерфейсе ревита, поэтому из контейнера должен возвращаться всегда один экземпляр для разных интерфейсов