### PR TITLE
Autocad_ObjectIdWrapper_ToString

### DIFF
--- a/src/Autocad/RxBim.Tools.Autocad/Models/Wrappers/ObjectIdWrapper.cs
+++ b/src/Autocad/RxBim.Tools.Autocad/Models/Wrappers/ObjectIdWrapper.cs
@@ -12,5 +12,9 @@
             : base(wrappedObject)
         {
         }
+
+        /// <inheritdoc />
+        public override string ToString()
+            => Object.ToString();
     }
 }


### PR DESCRIPTION
переопределение ToString для отображения Id объекта в окне логов.