### PR TITLE
Исправление ошибок RxBim.Tools и RxBim.Tools.Revit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ on:
     branches:
       - develop
       - 'feature/**'
+      - 'bugfix/**'
 
 jobs:
   windows-latest:

--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -22,7 +22,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Condition=" '$(UseDi)' == 'true' " Include="RxBim.Di" Version="2.0.1"/>
+        <PackageReference Condition=" '$(UseDi)' == 'true' " Include="RxBim.Di" Version="2.0.2-dev001"/>
     </ItemGroup>
 
     <PropertyGroup>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -11,7 +11,7 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
 [GitHubActions("CI",
     GitHubActionsImage.WindowsLatest,
     FetchDepth = 0,
-    OnPushBranches = new[] { DevelopBranch, FeatureBranches },
+    OnPushBranches = new[] { DevelopBranch, FeatureBranches, BugFixBranches },
     InvokedTargets = new[] { nameof(Test), nameof(IPublish.Publish) },
     ImportSecrets = new[] { "NUGET_API_KEY", "ALL_PACKAGES" })]
 /*[GitHubActions("PullRequest",
@@ -29,6 +29,7 @@ class Build : NukeBuild, IPublish, IVersions
     const string MasterBranch = "master";
     const string DevelopBranch = "develop";
     const string FeatureBranches = "feature/**";
+    const string BugFixBranches = "bugfix/**";
 
     public Build()
     {

--- a/samples/RxBim.Command.TableBuilder.Autocad.Sample/RxBim.Command.TableBuilder.Autocad.Sample.csproj
+++ b/samples/RxBim.Command.TableBuilder.Autocad.Sample/RxBim.Command.TableBuilder.Autocad.Sample.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.34.3" />
-        <PackageReference Include="RxBim.Command.Autocad.2019" Version="1.3.4" />
+        <PackageReference Include="RxBim.Command.Autocad.2019" Version="1.3.5-dev001" />
         <PackageReference Update="JetBrains.Annotations" Version="2022.1.0" />
         <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
           <PrivateAssets>all</PrivateAssets>

--- a/samples/RxBim.Command.TableBuilder.Revit.Sample/RxBim.Command.TableBuilder.Revit.Sample.csproj
+++ b/samples/RxBim.Command.TableBuilder.Revit.Sample/RxBim.Command.TableBuilder.Revit.Sample.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="RxBim.Command.Revit.2019" Version="1.9.4" />
+        <PackageReference Include="RxBim.Command.Revit.2019" Version="1.9.5-dev001" />
         <PackageReference Update="JetBrains.Annotations" Version="2022.1.0" />
         <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
           <PrivateAssets>all</PrivateAssets>

--- a/samples/RxBim.Tools.Autocad.Sample/RxBim.Tools.Autocad.Sample.csproj
+++ b/samples/RxBim.Tools.Autocad.Sample/RxBim.Tools.Autocad.Sample.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
       <PackageReference Remove="JetBrains.Annotations" />
-      <PackageReference Include="RxBim.Command.Autocad.2019" Version="1.3.4" />
+      <PackageReference Include="RxBim.Command.Autocad.2019" Version="1.3.5-dev001" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/RxBim.Tools.LogStorage.Revit.Sample/RxBim.Tools.LogStorage.Revit.Sample.csproj
+++ b/samples/RxBim.Tools.LogStorage.Revit.Sample/RxBim.Tools.LogStorage.Revit.Sample.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="RxBim.Command.Revit.2019" Version="1.9.4" />
+        <PackageReference Include="RxBim.Command.Revit.2019" Version="1.9.5-dev001" />
         <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Autocad/RxBim.Tools.Autocad/Directory.Build.Props
+++ b/src/Autocad/RxBim.Tools.Autocad/Directory.Build.Props
@@ -1,7 +1,7 @@
-<Project>
+﻿<Project>
 
     <PropertyGroup>
-        <ApiVersion>2.6</ApiVersion>
+        <ApiVersion>2.7-dev001</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/src/Autocad/RxBim.Tools.Civil/Directory.Build.Props
+++ b/src/Autocad/RxBim.Tools.Civil/Directory.Build.Props
@@ -1,7 +1,7 @@
-<Project>
+﻿<Project>
 
     <PropertyGroup>
-        <ApiVersion>0.6</ApiVersion>
+        <ApiVersion>0.7-dev001</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/src/Autocad/RxBim.Tools.TableBuilder.Autocad/Directory.Build.Props
+++ b/src/Autocad/RxBim.Tools.TableBuilder.Autocad/Directory.Build.Props
@@ -1,7 +1,7 @@
-<Project>
+﻿<Project>
     
     <PropertyGroup>
-        <ApiVersion>1.7</ApiVersion>
+        <ApiVersion>1.8-dev001</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/src/Core/RxBim.Tools.TableBuilder/Directory.Build.Props
+++ b/src/Core/RxBim.Tools.TableBuilder/Directory.Build.Props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
     <PropertyGroup>
-        <ApiVersion>2.1.3</ApiVersion>
+        <ApiVersion>2.1.4-dev001</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/src/Core/RxBim.Tools/Directory.Build.Props
+++ b/src/Core/RxBim.Tools/Directory.Build.Props
@@ -1,7 +1,7 @@
-<Project>
+﻿<Project>
 
     <PropertyGroup>
-        <ApiVersion>1.1.3</ApiVersion>
+        <ApiVersion>1.1.4-dev001</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/src/Core/RxBim.Tools/Services/TransactionService.cs
+++ b/src/Core/RxBim.Tools/Services/TransactionService.cs
@@ -105,7 +105,7 @@
             TContext? context = null)
             where TContext : class, ITransactionContextWrapper
         {
-            var transactionContext = _transactionFactory.GetDefaultContext<TContext>();
+            var transactionContext = context ?? _transactionFactory.GetDefaultContext<TContext>();
             using var transactionGroup =
                 _transactionFactory.CreateTransactionGroup(transactionContext, name);
             try

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Directory.Build.Props
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Directory.Build.Props
@@ -1,7 +1,7 @@
-<Project>
+﻿<Project>
 
     <PropertyGroup>
-        <ApiVersion>1.1.3</ApiVersion>
+        <ApiVersion>1.1.4-dev001</ApiVersion>
     </PropertyGroup>
     
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/src/GoogleSheet/RxBim.Tools.TableBuilder.GoogleSheet/Directory.Build.Props
+++ b/src/GoogleSheet/RxBim.Tools.TableBuilder.GoogleSheet/Directory.Build.Props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <ApiVersion>1.1.3</ApiVersion>
+        <ApiVersion>1.1.4-dev001</ApiVersion>
     </PropertyGroup>
     
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/src/Revit/RxBim.Tools.Revit/Abstractions/ISharedParameterService.cs
+++ b/src/Revit/RxBim.Tools.Revit/Abstractions/ISharedParameterService.cs
@@ -3,11 +3,13 @@
     using System.Collections.Generic;
     using Autodesk.Revit.DB;
     using CSharpFunctionalExtensions;
+    using JetBrains.Annotations;
     using Models;
 
     /// <summary>
     /// Сервис по работе с общими параметрами
     /// </summary>
+    [PublicAPI]
     public interface ISharedParameterService
     {
         /// <summary>

--- a/src/Revit/RxBim.Tools.Revit/Directory.Build.Props
+++ b/src/Revit/RxBim.Tools.Revit/Directory.Build.Props
@@ -1,7 +1,7 @@
-<Project>
+﻿<Project>
 
     <PropertyGroup>
-        <ApiVersion>3.9</ApiVersion>
+        <ApiVersion>3.10-dev001</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/src/Revit/RxBim.Tools.Revit/Services/SharedParameterService.cs
+++ b/src/Revit/RxBim.Tools.Revit/Services/SharedParameterService.cs
@@ -292,7 +292,7 @@
                     $"Не удалось добавить параметр '{sharedParameterInfo.Definition.ParameterName}'")
                 .TapIf(
                     sharedParameterInfo.CreateData.AllowVaryBetweenGroups,
-                    () => SetAllowVaryBetweenGroups(sharedParameterInfo.Definition.ParameterName));
+                    () => SetAllowVaryBetweenGroups(sharedParameterInfo.Definition.ParameterName, document));
 
             return result;
         }

--- a/src/Revit/RxBim.Tools.TableBuilder.Revit/Directory.Build.Props
+++ b/src/Revit/RxBim.Tools.TableBuilder.Revit/Directory.Build.Props
@@ -1,7 +1,7 @@
-<Project>
+﻿<Project>
     
     <PropertyGroup>
-        <ApiVersion>1.10</ApiVersion>
+        <ApiVersion>1.11-dev001</ApiVersion>
     </PropertyGroup>
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>


### PR DESCRIPTION
Исправил группу транзакций в `RxBim.Tools`, там всегда брался дефолтный документ.
Также исправил вызов метода `SetAllowVaryBetweenGroups`, чтобы в него также передавался документ.
Обновил пакет `RxBim.Di`.