### PR TITLE
Добавление картинок в таблицы

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-        <Version>4.0.1-dev001</Version>
+        <Version>4.0.1-dev002</Version>
         <TargetFramework>net472</TargetFramework>
         <PlatformTarget>x64</PlatformTarget>
         <LangVersion>12</LangVersion>
@@ -11,7 +11,7 @@
     <PropertyGroup>
         <SolutionDir>$(MSBuildThisFileDirectory)</SolutionDir>
     </PropertyGroup>
-    
+
     <Choose>
         <When Condition="!$(MSBuildProjectName.Contains('Tests')) AND !$(MSBuildProjectName.Contains('build'))">
             <PropertyGroup>
@@ -32,9 +32,9 @@
             </ItemGroup>
         </When>
     </Choose>
-    
+
     <ItemGroup>
-        <PackageReference Condition=" '$(UseDi)' == 'true' " Include="RxBim.Di" Version="3.0.0"/>
+        <PackageReference Condition=" '$(UseDi)' == 'true' " Include="RxBim.Di" Version="3.0.1-dev001"/>
     </ItemGroup>
 
     <Choose>
@@ -90,7 +90,7 @@
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove(RxBim.Build.Props, $(MSBuildProjectDirectory)))"
             Condition=" '$([MSBuild]::GetPathOfFileAbove(RxBim.Build.Props, $(MSBuildProjectDirectory)))' != '' AND $(NotRefenceApi) != true "/>
-    
+
     <PropertyGroup Condition="$(IsPackable) != false">
         <PackageId Condition="$(NotRefenceApi) == true">$(MSBuildProjectName)</PackageId>
         <PackageId Condition="$(NotRefenceApi) != true">$(MSBuildProjectName).$(ApplicationVersion)</PackageId>

--- a/samples/RxBim.Tools.TableBuilder.Excel.Sample/Program.cs
+++ b/samples/RxBim.Tools.TableBuilder.Excel.Sample/Program.cs
@@ -59,16 +59,12 @@ public class Program
 
     private static void AddExampleImage(TableBuilder table)
     {
-        var imageFile = Path.GetFullPath(@".\images\Example.jpg");
-        var imageStream = new MemoryStream(File.ReadAllBytes(imageFile));
-        var imageContent = new ImageCellContent(imageStream);
-
         foreach (var column in table.Columns)
             column.SetWidth(20);
 
         table.AddRow(r => r
             .SetHeight(300)
-            .Cells.First().SetContent(imageContent)
+            .Cells.First().SetContent(new ImageCellContent(@".\images\Example.jpg"))
             .MergeNext()
             .SetFormat(f => f
                 .SetContentVerticalAlignment(CellContentVerticalAlignment.Middle)

--- a/samples/RxBim.Tools.TableBuilder.Excel.Sample/Program.cs
+++ b/samples/RxBim.Tools.TableBuilder.Excel.Sample/Program.cs
@@ -64,7 +64,7 @@ public class Program
 
         table.AddRow(r => r
             .SetHeight(300)
-            .Cells.First().SetContent(new ImageCellContent(@".\images\Example.jpg"))
+            .Cells.First().SetContent(new ImageCellContent(File.ReadAllBytes(@".\images\Example.jpg")))
             .MergeNext()
             .SetFormat(f => f
                 .SetContentVerticalAlignment(CellContentVerticalAlignment.Middle)

--- a/samples/RxBim.Tools.TableBuilder.Excel.Sample/Program.cs
+++ b/samples/RxBim.Tools.TableBuilder.Excel.Sample/Program.cs
@@ -1,66 +1,84 @@
-﻿namespace RxBim.Tools.TableBuilder.Excel.Sample
+﻿namespace RxBim.Tools.TableBuilder.Excel.Sample;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using ClosedXML.Excel;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Console program.
+/// </summary>
+public class Program
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.IO;
-    using System.Linq;
-    using ClosedXML.Excel;
-    using Microsoft.Extensions.DependencyInjection;
-
     /// <summary>
-    /// Console program
+    /// Main.
     /// </summary>
-    public class Program
+    /// <param name="args">Arguments.</param>
+    public static void Main(string[] args)
     {
-        /// <summary>
-        /// Main
-        /// </summary>
-        /// <param name="args">Arguments</param>
-        public static void Main(string[] args)
-        {
-            // Create a simple container and register the table converter.
-            var container = CreateContainer();
+        // Create a simple container and register the table converter.
+        var container = CreateContainer();
 
-            // Getting a converter service
-            var converter = container.GetRequiredService<IExcelTableConverter>();
-            var parameters = new ExcelTableConverterParameters();
+        // Getting a converter service.
+        var converter = container.GetRequiredService<IExcelTableConverter>();
+        var parameters = new ExcelTableConverterParameters();
 
-            // Create an example table
-            var table = CreateTable();
+        // Create an example table.
+        var table = CreateTable();
 
-            // Convert the table to an Excel workbook
-            var workbook = converter.Convert(table, parameters);
+        // Convert the table to an Excel workbook.
+        var workbook = converter.Convert(table, parameters);
 
-            // Save Excel file and open
-            var excelFile = Save(workbook);
-            Process.Start(excelFile);
-        }
+        // Save Excel file and open.
+        var excelFile = Save(workbook);
+        Process.Start(excelFile);
+    }
 
-        private static string Save(IXLWorkbook workbook)
-        {
-            var tempFile = Path.GetTempFileName();
-            var excelFile = Path.ChangeExtension(tempFile, "xlsx");
-            File.Move(tempFile, excelFile);
-            workbook.SaveAs(excelFile);
-            return excelFile;
-        }
+    private static string Save(IXLWorkbook workbook)
+    {
+        var tempFile = Path.GetTempFileName();
+        var excelFile = Path.ChangeExtension(tempFile, "xlsx");
+        File.Move(tempFile, excelFile);
+        workbook.SaveAs(excelFile);
+        return excelFile;
+    }
 
-        private static Table CreateTable()
-        {
-            List<(string Property, string Value)> values =
-                Enumerable.Range(0, 10).Select(s => ($"Property-{s}", $"Value-{s}")).ToList();
+    private static Table CreateTable()
+    {
+        List<(string Property, string Value)> values =
+            Enumerable.Range(0, 10).Select(s => ($"Property-{s}", $"Value-{s}")).ToList();
 
-            var table = new TableBuilder();
-            table.AddRowsFromList(values, 0, 0, i => i.Property, i => i.Value);
-            return table;
-        }
+        var table = new TableBuilder();
+        table.AddRowsFromList(values, 0, 0, i => i.Property, i => i.Value);
+        AddExampleImage(table);
+        return table;
+    }
 
-        private static IServiceProvider CreateContainer()
-        {
-            var container = new ServiceCollection();
-            container.AddExcelTableBuilder();
-            return container.BuildServiceProvider();
-        }
+    private static void AddExampleImage(TableBuilder table)
+    {
+        var imageFile = Path.GetFullPath(@".\images\Example.jpg");
+        var imageStream = new MemoryStream(File.ReadAllBytes(imageFile));
+        var imageContent = new ImageCellContent(imageStream);
+
+        foreach (var column in table.Columns)
+            column.SetWidth(20);
+
+        table.AddRow(r => r
+            .SetHeight(300)
+            .Cells.First().SetContent(imageContent)
+            .MergeNext()
+            .SetFormat(f => f
+                .SetContentVerticalAlignment(CellContentVerticalAlignment.Middle)
+                .SetContentHorizontalAlignment(CellContentHorizontalAlignment.Center)));
+    }
+
+    private static IServiceProvider CreateContainer()
+    {
+        var container = new ServiceCollection();
+        container.AddExcelTableBuilder();
+        return container.BuildServiceProvider();
     }
 }

--- a/samples/RxBim.Tools.TableBuilder.Excel.Sample/README.md
+++ b/samples/RxBim.Tools.TableBuilder.Excel.Sample/README.md
@@ -1,3 +1,3 @@
 # Example 
 An example of a table converting to an Excel workbook.
-<p align="center"><img width="300px" src="/images/Example.jpg" alt="Example"/></p>
+<p align="center"><img width="300px" src="./images/Example.jpg" alt="Example"/></p>

--- a/samples/RxBim.Tools.TableBuilder.Excel.Sample/RxBim.Tools.TableBuilder.Excel.Sample.csproj
+++ b/samples/RxBim.Tools.TableBuilder.Excel.Sample/RxBim.Tools.TableBuilder.Excel.Sample.csproj
@@ -1,11 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
-    <UseDi>true</UseDi>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Excel\RxBim.Tools.TableBuilder.Excel\RxBim.Tools.TableBuilder.Excel.csproj" />
-  </ItemGroup>  
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <OutputType>Exe</OutputType>
+        <Nullable>enable</Nullable>
+        <UseDi>true</UseDi>                
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Excel\RxBim.Tools.TableBuilder.Excel\RxBim.Tools.TableBuilder.Excel.csproj"/>
+    </ItemGroup>
+    
+    <ItemGroup>
+        <None Include="images\Example.jpg" CopyToOutputDirectory="Always"/>
+    </ItemGroup>
 </Project>

--- a/src/Autocad/RxBim.Tools.TableBuilder.Autocad/Converters/AutocadTableConverter.cs
+++ b/src/Autocad/RxBim.Tools.TableBuilder.Autocad/Converters/AutocadTableConverter.cs
@@ -68,8 +68,6 @@
                         case CellContent<object> valueData:
                             acadCell.Value = valueData.Value;
                             break;
-                        default:
-                            throw new ArgumentOutOfRangeException($"Undefined cell data type '{cellData.Content}'.");
                     }
                 }
             }

--- a/src/Core/RxBim.Tools.TableBuilder/Models/Content/ImageCellContent.cs
+++ b/src/Core/RxBim.Tools.TableBuilder/Models/Content/ImageCellContent.cs
@@ -1,0 +1,37 @@
+﻿namespace RxBim.Tools.TableBuilder;
+
+using System.IO;
+using JetBrains.Annotations;
+
+/// <summary>
+/// The image content of cell.
+/// </summary>
+[UsedImplicitly]
+public class ImageCellContent : ICellContent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageCellContent"/> class.
+    /// </summary>
+    /// <param name="imageStream">Stream of image.</param>
+    /// <param name="scale">Scale.</param>
+    public ImageCellContent(
+        Stream imageStream,
+        double scale = 1)
+    {
+        ImageStream = imageStream;
+        Scale = scale;
+    }
+
+    /// <inheritdoc />
+    public object? ValueObject => null;
+
+    /// <summary>
+    /// Stream of image.
+    /// </summary>
+    public Stream ImageStream { get; }
+
+    /// <summary>
+    /// Scale.
+    /// </summary>
+    public double Scale { get; }
+}

--- a/src/Core/RxBim.Tools.TableBuilder/Models/Content/ImageCellContent.cs
+++ b/src/Core/RxBim.Tools.TableBuilder/Models/Content/ImageCellContent.cs
@@ -1,6 +1,5 @@
 ﻿namespace RxBim.Tools.TableBuilder;
 
-using System.IO;
 using JetBrains.Annotations;
 
 /// <summary>
@@ -12,13 +11,13 @@ public class ImageCellContent : ICellContent
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageCellContent"/> class.
     /// </summary>
-    /// <param name="imageStream">Stream of image.</param>
+    /// <param name="imageFile">Image file path.</param>
     /// <param name="scale">Scale.</param>
     public ImageCellContent(
-        Stream imageStream,
+        string imageFile,
         double scale = 1)
     {
-        ImageStream = imageStream;
+        ImageFile = imageFile;
         Scale = scale;
     }
 
@@ -26,9 +25,9 @@ public class ImageCellContent : ICellContent
     public object? ValueObject => null;
 
     /// <summary>
-    /// Stream of image.
+    /// Image file.
     /// </summary>
-    public Stream ImageStream { get; }
+    public string ImageFile { get; }
 
     /// <summary>
     /// Scale.

--- a/src/Core/RxBim.Tools.TableBuilder/Models/Content/ImageCellContent.cs
+++ b/src/Core/RxBim.Tools.TableBuilder/Models/Content/ImageCellContent.cs
@@ -11,26 +11,19 @@ public class ImageCellContent : ICellContent
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageCellContent"/> class.
     /// </summary>
-    /// <param name="imageFile">Image file path.</param>
-    /// <param name="scale">Scale.</param>
-    public ImageCellContent(
-        string imageFile,
-        double scale = 1)
+    /// <param name="image">Image data.</param>
+    /// <param name="value">Value.</param>
+    public ImageCellContent(byte[] image, object? value = null)
     {
-        ImageFile = imageFile;
-        Scale = scale;
+        Image = image;
+        ValueObject = value;
     }
 
     /// <inheritdoc />
-    public object? ValueObject => null;
+    public object? ValueObject { get; }
 
     /// <summary>
     /// Image file.
     /// </summary>
-    public string ImageFile { get; }
-
-    /// <summary>
-    /// Scale.
-    /// </summary>
-    public double Scale { get; }
+    public byte[] Image { get; }
 }

--- a/src/Core/RxBim.Tools.TableBuilder/Models/Content/ImageCellContent.cs
+++ b/src/Core/RxBim.Tools.TableBuilder/Models/Content/ImageCellContent.cs
@@ -23,7 +23,7 @@ public class ImageCellContent : ICellContent
     public object? ValueObject { get; }
 
     /// <summary>
-    /// Image file.
+    /// Image data.
     /// </summary>
     public byte[] Image { get; }
 }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Abstractions/IExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Abstractions/IExcelTableConverter.cs
@@ -1,11 +1,24 @@
 ﻿namespace RxBim.Tools.TableBuilder;
 
 using ClosedXML.Excel;
+using JetBrains.Annotations;
 
 /// <summary>
-/// Defines an interface of a <see cref="Table"/> converter to an Excle workbook.
+/// Defines an interface of a <see cref="Table"/> converter to an Excel workbook.
 /// </summary>
+[PublicAPI]
 public interface IExcelTableConverter
     : ITableConverter<Table, ExcelTableConverterParameters, IXLWorkbook>
 {
+    /// <summary>
+    /// Возвращает ширину в пикселях.
+    /// </summary>
+    /// <param name="width">Ширина в поинтах Excel.</param>
+    double ConvertWidthToPixels(double width);
+
+    /// <summary>
+    /// Возвращает высоту в пикселях.
+    /// </summary>
+    /// <param name="height">Высота в поинтах Excel.</param>
+    double ConvertHeightToPixels(double height);
 }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Abstractions/IExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Abstractions/IExcelTableConverter.cs
@@ -8,17 +8,4 @@ using JetBrains.Annotations;
 /// </summary>
 [PublicAPI]
 public interface IExcelTableConverter
-    : ITableConverter<Table, ExcelTableConverterParameters, IXLWorkbook>
-{
-    /// <summary>
-    /// Returns the width in pixels.
-    /// </summary>
-    /// <param name="width">Width in Excel points.</param>
-    double ConvertWidthToPixels(double width);
-
-    /// <summary>
-    /// Returns the height in pixels.
-    /// </summary>
-    /// <param name="height">Height in Excel points.</param>
-    double ConvertHeightToPixels(double height);
-}
+    : ITableConverter<Table, ExcelTableConverterParameters, IXLWorkbook>;

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Abstractions/IExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Abstractions/IExcelTableConverter.cs
@@ -11,14 +11,14 @@ public interface IExcelTableConverter
     : ITableConverter<Table, ExcelTableConverterParameters, IXLWorkbook>
 {
     /// <summary>
-    /// Возвращает ширину в пикселях.
+    /// Returns the width in pixels.
     /// </summary>
-    /// <param name="width">Ширина в поинтах Excel.</param>
+    /// <param name="width">Width in Excel points.</param>
     double ConvertWidthToPixels(double width);
 
     /// <summary>
-    /// Возвращает высоту в пикселях.
+    /// Returns the height in pixels.
     /// </summary>
-    /// <param name="height">Высота в поинтах Excel.</param>
+    /// <param name="height">Height in Excel points.</param>
     double ConvertHeightToPixels(double height);
 }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
@@ -13,22 +13,22 @@ using JetBrains.Annotations;
 internal class ExcelTableConverter : IExcelTableConverter
 {
     /// <summary>
-    /// Стандартное разрешение экрана.
+    /// Standard DPI.
     /// </summary>
     private const double StandardDpi = 96;
 
     /// <summary>
-    /// Разрешение экрана определено.
+    /// Is DPI calculated.
     /// </summary>
     private static bool _isDpiCalculated;
 
     /// <summary>
-    /// Разрешение экрана по X.
+    /// DPI by X.
     /// </summary>
     private static uint _dpiX;
 
     /// <summary>
-    /// Разрешение экрана по Y.
+    /// DPI by Y.
     /// </summary>
     private static uint _dpiY;
 
@@ -79,10 +79,10 @@ internal class ExcelTableConverter : IExcelTableConverter
     /// <inheritdoc/>
     public double ConvertWidthToPixels(double width)
     {
-        // DPI (разрешение экрана) нужно для определения ширины и высоты Excel в пикселях.
+        // DPI (screen resolution) is used to determine the width and height of Excel in pixels.
         CalculateDpi();
 
-        // Магические константы определения ширины столбца и высоты строки в пикселях (из гугла).
+        // Magic constants for determining column width and row height in pixels (from Google).
         return (width * 7 + 5) / (StandardDpi / _dpiX);
     }
 
@@ -341,7 +341,7 @@ internal class ExcelTableConverter : IExcelTableConverter
         if (_isDpiCalculated)
             return;
 
-        // Определение dpi через Graphics не рабатает (не находит сборку System.Drawing.Common).
+        // Determining dpi via Graphics does not work (does not find the System.Drawing.Common assembly).
         var hwnd = GetDesktopWindow();
         var hMonitor = MonitorFromWindow(hwnd, 0);
         GetDpiForMonitor(hMonitor, 0, out _dpiX, out _dpiY);

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
@@ -189,7 +189,7 @@ internal class ExcelTableConverter : IExcelTableConverter
     private void SetImage(IXLCell cell, ImageCellContent image)
     {
         var pictureCell = cell.Worksheet
-            .AddPicture(image.ImageStream)
+            .AddPicture(image.ImageFile)
             .MoveTo(cell)
             .Scale(image.Scale, true);
 

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
@@ -15,7 +15,7 @@ internal class ExcelTableConverter : IExcelTableConverter
     /// <summary>
     /// Standard DPI.
     /// </summary>
-    private const double StandardDpi = 96;
+    private const int StandardDpi = 96;
 
     /// <summary>
     /// Is DPI calculated.
@@ -83,14 +83,17 @@ internal class ExcelTableConverter : IExcelTableConverter
         CalculateDpi();
 
         // Magic constants for determining column width and row height in pixels (from Google).
-        return (width * 7 + 5) / (StandardDpi / _dpiX);
+        // https://github.com/ClosedXML/ClosedXML/issues/846
+        return (width * 7 + 12) / ((double)StandardDpi / _dpiX);
     }
 
     /// <inheritdoc/>
     public double ConvertHeightToPixels(double height)
     {
         CalculateDpi();
-        return height / 0.75 / (StandardDpi / _dpiY);
+
+        // https://learn.microsoft.com/en-us/answers/questions/257675/excel-row-height-logic-calculation
+        return height / 0.75 / ((double)StandardDpi / _dpiY);
     }
 
     [DllImport("shcore.dll")]
@@ -345,6 +348,13 @@ internal class ExcelTableConverter : IExcelTableConverter
         var hwnd = GetDesktopWindow();
         var hMonitor = MonitorFromWindow(hwnd, 0);
         GetDpiForMonitor(hMonitor, 0, out _dpiX, out _dpiY);
+
+        if (_dpiX == 0)
+            _dpiX = StandardDpi;
+
+        if (_dpiY == 0)
+            _dpiY = StandardDpi;
+
         _isDpiCalculated = true;
     }
 }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
@@ -1,225 +1,350 @@
-﻿namespace RxBim.Tools.TableBuilder
+﻿namespace RxBim.Tools.TableBuilder;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using ClosedXML.Excel;
+using JetBrains.Annotations;
+
+/// <inheritdoc />
+[UsedImplicitly]
+internal class ExcelTableConverter : IExcelTableConverter
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
-    using ClosedXML.Excel;
-    using JetBrains.Annotations;
+    /// <summary>
+    /// Стандартное разрешение экрана.
+    /// </summary>
+    private const double StandardDpi = 96;
 
     /// <summary>
-    /// Defines a <see cref="Table"/> converter to an Excle workbook.
+    /// Разрешение экрана определено.
     /// </summary>
-    [UsedImplicitly]
-    internal class ExcelTableConverter : IExcelTableConverter
+    private static bool _isDpiCalculated;
+
+    /// <summary>
+    /// Разрешение экрана по X.
+    /// </summary>
+    private static uint _dpiX;
+
+    /// <summary>
+    /// Разрешение экрана по Y.
+    /// </summary>
+    private static uint _dpiY;
+
+    /// <inheritdoc />
+    public IXLWorkbook Convert(Table table, ExcelTableConverterParameters parameters)
     {
-        /// <inheritdoc />
-        public IXLWorkbook Convert(Table table, ExcelTableConverterParameters parameters)
+        var workbook = parameters.Workbook ?? new XLWorkbook();
+        var worksheet = workbook.Worksheets.Add(parameters.WorksheetName ?? "Sheet1");
+
+        var mergedCells = new List<CellRange>();
+
+        // Setting all columns widths and rows heights.
+        ApplyToColumns(table, worksheet, (xlColumn, columnIndex) =>
         {
-            var workbook = parameters.Workbook ?? new XLWorkbook();
-            var worksheet = workbook.Worksheets.Add(parameters.WorksheetName ?? "Sheet1");
+            if (table.Columns[columnIndex].IsAdjustedToContent)
+                xlColumn.AdjustToContents();
+            else
+                xlColumn.Width = table.Columns[columnIndex].Width ?? table.GetAverageColumnWidth();
 
-            var mergedCells = new List<CellRange>();
-
-            var sheetColumnIndex = 1;
-            for (var currentColumnIndex = 0;
-                 currentColumnIndex < table.Columns.Count;
-                 currentColumnIndex++, sheetColumnIndex++)
-            {
-                var column = worksheet.Column(sheetColumnIndex);
-                if (table.Columns[currentColumnIndex].IsAdjustedToContent)
+            ApplyToRows(
+                table,
+                worksheet,
+                (xlRow, rowIndex) =>
                 {
-                    column.AdjustToContents();
-                }
-                else
-                {
-                    column.Width = table.Columns[currentColumnIndex].Width ?? table.GetAverageColumnWidth();
-                }
+                    if (table.Rows[rowIndex].IsAdjustedToContent)
+                        xlRow.AdjustToContents();
+                    else
+                        xlRow.Height = table.Rows[rowIndex].Height ?? table.GetAverageRowHeight();
+                });
+        });
 
-                FillRow(table, worksheet, currentColumnIndex, sheetColumnIndex, mergedCells);
-            }
+        // Fill cells.
+        ApplyToColumns(table, worksheet, (_, columnIndex) =>
+            ApplyToRows(table, worksheet, (xlRow, rowIndex) =>
+                FillRow(table, worksheet, xlRow, columnIndex, rowIndex, mergedCells)));
 
-            if (parameters.FreezeRows > 0)
-                worksheet.SheetView.Freeze(parameters.FreezeRows, table.Columns.Count);
+        if (parameters.FreezeRows > 0)
+            worksheet.SheetView.Freeze(parameters.FreezeRows, table.Columns.Count);
 
-            var (fromRow, fromColumn, toRow, toColumn) = parameters.AutoFilterRange;
+        var (fromRow, fromColumn, toRow, toColumn) = parameters.AutoFilterRange;
 
-            if (fromRow > 0 && fromColumn > 0)
-                worksheet.Range(fromRow, fromColumn, toRow, toColumn).SetAutoFilter(true);
+        if (fromRow > 0 && fromColumn > 0)
+            worksheet.Range(fromRow, fromColumn, toRow, toColumn).SetAutoFilter(true);
 
-            return workbook;
+        return workbook;
+    }
+
+    /// <inheritdoc/>
+    public double ConvertWidthToPixels(double width)
+    {
+        // DPI (разрешение экрана) нужно для определения ширины и высоты Excel в пикселях.
+        CalculateDpi();
+
+        // Магические константы определения ширины столбца и высоты строки в пикселях (из гугла).
+        return (width * 7 + 5) / (StandardDpi / _dpiX);
+    }
+
+    /// <inheritdoc/>
+    public double ConvertHeightToPixels(double height)
+    {
+        CalculateDpi();
+        return height / 0.75 / (StandardDpi / _dpiY);
+    }
+
+    [DllImport("shcore.dll")]
+    private static extern int GetDpiForMonitor(IntPtr hmonitor, int dpiType, out uint dpiX, out uint dpiY);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetDesktopWindow();
+
+    private void ApplyToColumns(Table table, IXLWorksheet worksheet, Action<IXLColumn, int> action)
+    {
+        for (var columnIndex = 0; columnIndex < table.Columns.Count; columnIndex++)
+        {
+            var xlColumn = worksheet.Column(columnIndex + 1);
+            action(xlColumn, columnIndex);
+        }
+    }
+
+    private void ApplyToRows(
+        Table table,
+        IXLWorksheet worksheet,
+        Action<IXLRow, int> action)
+    {
+        for (var rowIndex = 0; rowIndex < table.Rows.Count; rowIndex++)
+        {
+            var xlRow = worksheet.Row(rowIndex + 1);
+            action(xlRow, rowIndex);
+        }
+    }
+
+    private void FillRow(
+        Table table,
+        IXLWorksheet worksheet,
+        IXLRow xlRow,
+        int columnIndex,
+        int rowIndex,
+        List<CellRange> mergedCells)
+    {
+        var cell = table[rowIndex, columnIndex];
+        var sheetCell = worksheet.Cell(rowIndex + 1, columnIndex + 1);
+
+        SetFormat(sheetCell, cell.GetComposedFormat());
+
+        if (table.Rows[rowIndex].IsAdjustedToContent)
+            xlRow.AdjustToContents();
+        else
+            xlRow.Height = table.Rows[rowIndex].Height ?? table.GetAverageRowHeight();
+
+        // Merge logic
+        if (!cell.Merged || cell.MergeArea == null)
+        {
+            SetData(sheetCell, cell.Content);
+            return;
         }
 
-        private void FillRow(
-            Table table,
-            IXLWorksheet worksheet,
-            int currentColumnIndex,
-            int sheetColumnIndex,
-            List<CellRange> mergedCells)
+        // If such an area already exists, then the data is written only to the first cell.
+        if (mergedCells.Exists(x => Equals(x, cell.MergeArea)))
+            return;
+
+        mergedCells.Add(cell.MergeArea.Value);
+
+        worksheet.Range(
+            cell.MergeArea.Value.TopRow + 1,
+            cell.MergeArea.Value.LeftColumn + 1,
+            cell.MergeArea.Value.BottomRow + 1,
+            cell.MergeArea.Value.RightColumn + 1).Merge();
+
+        SetData(sheetCell, cell.Content);
+    }
+
+    private void SetData(IXLCell cell, ICellContent content)
+    {
+        switch (content)
         {
-            var sheetRowIndex = 1;
-            for (var currentRowIndex = 0; currentRowIndex < table.Rows.Count; currentRowIndex++, sheetRowIndex++)
+            case FormulaCellContent formula:
+                cell.FormulaA1 = GetFormula(cell.Worksheet, formula);
+                break;
+
+            case NumericCellContent numeric:
+                cell.Value = numeric.ValueObject;
+                cell.Style.NumberFormat.Format = numeric.Format;
+                break;
+
+            case ImageCellContent image:
+                SetImage(cell, image);
+                break;
+
+            default:
+                cell.SetValue(content.ValueObject);
+                break;
+        }
+    }
+
+    private void SetImage(IXLCell cell, ImageCellContent image)
+    {
+        var pictureCell = cell.Worksheet
+            .AddPicture(image.ImageStream)
+            .MoveTo(cell)
+            .Scale(image.Scale, true);
+
+        var left = cell.Style.Alignment.Horizontal switch
+        {
+            XLAlignmentHorizontalValues.Center =>
+                (ConvertWidthToPixels(GetCellWidth(cell)) - pictureCell.Width) / 2,
+            XLAlignmentHorizontalValues.Right =>
+                ConvertWidthToPixels(GetCellWidth(cell)) - pictureCell.Width,
+            _ => 0
+        };
+
+        var top = cell.Style.Alignment.Vertical switch
+        {
+            XLAlignmentVerticalValues.Center =>
+                (ConvertHeightToPixels(GetCellHeight(cell)) - pictureCell.Height) / 2,
+            XLAlignmentVerticalValues.Bottom =>
+                ConvertHeightToPixels(GetCellHeight(cell)) - pictureCell.Height,
+            _ => 0
+        };
+
+        pictureCell.MoveTo(cell, (int)left, (int)top);
+    }
+
+    private double GetCellWidth(IXLCell cell) =>
+        cell.IsMerged() ?
+            cell.MergedRange().Columns().Sum(c => c.WorksheetColumn().Width)
+            : cell.WorksheetColumn().Width;
+
+    private double GetCellHeight(IXLCell cell) =>
+        cell.IsMerged() ?
+            cell.MergedRange().Rows().Sum(c => c.WorksheetRow().Height)
+            : cell.WorksheetRow().Height;
+
+    private string GetFormula(IXLWorksheet ws, FormulaCellContent formula)
+    {
+        var sFormula = new StringBuilder();
+
+        var (fromRow, fromColumn, toRow, toColumn) = formula.CellRange;
+
+        sFormula.Append(formula.Formula switch
             {
-                var row = worksheet.Row(sheetRowIndex);
-                var cell = table[currentRowIndex, currentColumnIndex];
-                var sheetCell = worksheet.Cell(sheetRowIndex, sheetColumnIndex);
+                Formulas.Sum => "SUM",
+                _ => throw new NotImplementedException(formula.Formula.ToString())
+            })
+            .Append("(")
+            .Append(ws.Range(fromRow, fromColumn, toRow, toColumn).RangeAddress)
+            .Append(")");
 
-                SetData(sheetCell, cell.Content);
-                SetFormat(sheetCell, cell.GetComposedFormat());
+        return sFormula.ToString();
+    }
 
-                // Merge logic
-                if (!cell.Merged || cell.MergeArea == null || mergedCells.Exists(x => Equals(x, cell.MergeArea)))
-                    continue;
+    private void SetFormat(IXLCell sheetCell, CellFormatStyle cellFormat)
+    {
+        var cellStyle = sheetCell.Style;
 
-                mergedCells.Add(cell.MergeArea.Value);
+        SetBackgroundFormat(cellFormat, cellStyle);
+        SetTextFormat(cellFormat, cellStyle);
+        SetAlignmentFormat(cellFormat, cellStyle);
+        SetBordersFormat(cellFormat, cellStyle);
+    }
 
-                worksheet.Range(
-                    cell.MergeArea.Value.TopRow + 1,
-                    cell.MergeArea.Value.LeftColumn + 1,
-                    cell.MergeArea.Value.BottomRow + 1,
-                    cell.MergeArea.Value.RightColumn + 1).Merge();
-
-                if (table.Rows[currentRowIndex].IsAdjustedToContent)
-                {
-                    row.AdjustToContents();
-                }
-                else
-                {
-                    row.Height = table.Rows[currentRowIndex].Height ?? table.GetAverageRowHeight();
-                }
-            }
-        }
-
-        private void SetData(IXLCell cell, ICellContent content)
+    private void SetBackgroundFormat(CellFormatStyle cellFormat, IXLStyle cellStyle)
+    {
+        if (cellFormat.BackgroundColor != null)
         {
-            switch (content)
-            {
-                case FormulaCellContent formula:
-                    cell.FormulaA1 = GetFormula(cell.Worksheet, formula);
-                    break;
-
-                case NumericCellContent numeric:
-                    cell.Value = numeric.ValueObject;
-                    cell.Style.NumberFormat.Format = numeric.Format;
-                    break;
-
-                default:
-                    cell.SetValue(content.ValueObject);
-                    break;
-            }
+            cellStyle.Fill.PatternType = XLFillPatternValues.Solid;
+            cellStyle.Fill.SetBackgroundColor(XLColor.FromColor(cellFormat.BackgroundColor.Value));
         }
+    }
 
-        private string GetFormula(IXLWorksheet ws, FormulaCellContent formula)
+    private void SetAlignmentFormat(CellFormatStyle cellFormat, IXLStyle cellStyle)
+    {
+        if (cellFormat.ContentHorizontalAlignment != null)
+            cellStyle.Alignment.SetHorizontal(GetExcelHorizontalAlignment(cellFormat.ContentHorizontalAlignment.Value));
+
+        if (cellFormat.ContentVerticalAlignment != null)
+            cellStyle.Alignment.SetVertical(GetExcelVerticalAlignment(cellFormat.ContentVerticalAlignment.Value));
+    }
+
+    private void SetBordersFormat(CellFormatStyle cellFormat, IXLStyle cellStyle)
+    {
+        if (cellFormat.Borders.Top != null)
+            cellStyle.Border.TopBorder = GetExcelBorderStyle(cellFormat.Borders.Top.Value);
+
+        if (cellFormat.Borders.Right != null)
+            cellStyle.Border.RightBorder = GetExcelBorderStyle(cellFormat.Borders.Right.Value);
+
+        if (cellFormat.Borders.Bottom != null)
+            cellStyle.Border.BottomBorder = GetExcelBorderStyle(cellFormat.Borders.Bottom.Value);
+
+        if (cellFormat.Borders.Left != null)
+            cellStyle.Border.LeftBorder = GetExcelBorderStyle(cellFormat.Borders.Left.Value);
+    }
+
+    private void SetTextFormat(CellFormatStyle cellFormat, IXLStyle cellStyle)
+    {
+        if (!string.IsNullOrEmpty(cellFormat.TextFormat.FontFamily))
+            cellStyle.Font.FontName = cellFormat.TextFormat.FontFamily;
+
+        if (cellFormat.TextFormat.Bold != null)
+            cellStyle.Font.Bold = cellFormat.TextFormat.Bold.Value;
+
+        if (cellFormat.TextFormat.Italic != null)
+            cellStyle.Font.Italic = cellFormat.TextFormat.Italic.Value;
+
+        if (cellFormat.TextFormat.TextColor != null)
+            cellStyle.Font.SetFontColor(XLColor.FromColor(cellFormat.TextFormat.TextColor.Value));
+
+        if (cellFormat.TextFormat.TextSize != null)
+            cellStyle.Font.FontSize = cellFormat.TextFormat.TextSize.Value;
+
+        if (cellFormat.TextFormat.WrapText != null)
+            cellStyle.Alignment.WrapText = cellFormat.TextFormat.WrapText.Value;
+
+        if (cellFormat.TextFormat.ShrinkToFit != null)
+            cellStyle.Alignment.ShrinkToFit = cellFormat.TextFormat.ShrinkToFit.Value;
+    }
+
+    private XLAlignmentVerticalValues GetExcelVerticalAlignment(CellContentVerticalAlignment verticalAlignment) =>
+        verticalAlignment switch
         {
-            var sFormula = new StringBuilder();
+            CellContentVerticalAlignment.Top => XLAlignmentVerticalValues.Top,
+            CellContentVerticalAlignment.Middle => XLAlignmentVerticalValues.Center,
+            CellContentVerticalAlignment.Bottom => XLAlignmentVerticalValues.Bottom,
+            _ => throw new NotImplementedException(verticalAlignment.ToString())
+        };
 
-            var (fromRow, fromColumn, toRow, toColumn) = formula.CellRange;
-
-            sFormula.Append(formula.Formula switch
-                {
-                    Formulas.Sum => "SUM",
-                    _ => throw new NotImplementedException(formula.Formula.ToString())
-                })
-                .Append("(")
-                .Append(ws.Range(fromRow, fromColumn, toRow, toColumn).RangeAddress)
-                .Append(")");
-
-            return sFormula.ToString();
-        }
-
-        private void SetFormat(IXLCell sheetCell, CellFormatStyle cellFormat)
+    private XLAlignmentHorizontalValues GetExcelHorizontalAlignment(CellContentHorizontalAlignment horizontalAlignment) =>
+        horizontalAlignment switch
         {
-            var cellStyle = sheetCell.Style;
+            CellContentHorizontalAlignment.Center => XLAlignmentHorizontalValues.Center,
+            CellContentHorizontalAlignment.Left => XLAlignmentHorizontalValues.Left,
+            CellContentHorizontalAlignment.Right => XLAlignmentHorizontalValues.Right,
+            _ => throw new NotImplementedException(horizontalAlignment.ToString())
+        };
 
-            SetBackgroundFormat(cellFormat, cellStyle);
-            SetTextFormat(cellFormat, cellStyle);
-            SetAlignmentFormat(cellFormat, cellStyle);
-            SetBordersFormat(cellFormat, cellStyle);
-        }
-
-        private void SetBackgroundFormat(CellFormatStyle cellFormat, IXLStyle cellStyle)
+    private XLBorderStyleValues GetExcelBorderStyle(CellBorderType borderType) =>
+        borderType switch
         {
-            if (cellFormat.BackgroundColor != null)
-            {
-                cellStyle.Fill.PatternType = XLFillPatternValues.Solid;
-                cellStyle.Fill.SetBackgroundColor(XLColor.FromColor(cellFormat.BackgroundColor.Value));
-            }
-        }
+            CellBorderType.Hidden => XLBorderStyleValues.None,
+            CellBorderType.Bold => XLBorderStyleValues.Medium,
+            CellBorderType.Thin => XLBorderStyleValues.Thin,
+            _ => throw new NotImplementedException(borderType.ToString())
+        };
 
-        private void SetAlignmentFormat(CellFormatStyle cellFormat, IXLStyle cellStyle)
-        {
-            if (cellFormat.ContentHorizontalAlignment != null)
-                cellStyle.Alignment.SetHorizontal(GetExcelHorizontalAlignment(cellFormat.ContentHorizontalAlignment.Value));
+    private void CalculateDpi()
+    {
+        if (_isDpiCalculated)
+            return;
 
-            if (cellFormat.ContentVerticalAlignment != null)
-                cellStyle.Alignment.SetVertical(GetExcelVerticalAlignment(cellFormat.ContentVerticalAlignment.Value));
-        }
-
-        private void SetBordersFormat(CellFormatStyle cellFormat, IXLStyle cellStyle)
-        {
-            if (cellFormat.Borders.Top != null)
-                cellStyle.Border.TopBorder = GetExcelBorderStyle(cellFormat.Borders.Top.Value);
-
-            if (cellFormat.Borders.Right != null)
-                cellStyle.Border.RightBorder = GetExcelBorderStyle(cellFormat.Borders.Right.Value);
-
-            if (cellFormat.Borders.Bottom != null)
-                cellStyle.Border.BottomBorder = GetExcelBorderStyle(cellFormat.Borders.Bottom.Value);
-
-            if (cellFormat.Borders.Left != null)
-                cellStyle.Border.LeftBorder = GetExcelBorderStyle(cellFormat.Borders.Left.Value);
-        }
-
-        private void SetTextFormat(CellFormatStyle cellFormat, IXLStyle cellStyle)
-        {
-            if (!string.IsNullOrEmpty(cellFormat.TextFormat.FontFamily))
-                cellStyle.Font.FontName = cellFormat.TextFormat.FontFamily;
-
-            if (cellFormat.TextFormat.Bold != null)
-                cellStyle.Font.Bold = cellFormat.TextFormat.Bold.Value;
-
-            if (cellFormat.TextFormat.Italic != null)
-                cellStyle.Font.Italic = cellFormat.TextFormat.Italic.Value;
-
-            if (cellFormat.TextFormat.TextColor != null)
-                cellStyle.Font.SetFontColor(XLColor.FromColor(cellFormat.TextFormat.TextColor.Value));
-
-            if (cellFormat.TextFormat.TextSize != null)
-                cellStyle.Font.FontSize = cellFormat.TextFormat.TextSize.Value;
-
-            if (cellFormat.TextFormat.WrapText != null)
-                cellStyle.Alignment.WrapText = cellFormat.TextFormat.WrapText.Value;
-
-            if (cellFormat.TextFormat.ShrinkToFit != null)
-                cellStyle.Alignment.ShrinkToFit = cellFormat.TextFormat.ShrinkToFit.Value;
-        }
-
-        private XLAlignmentVerticalValues GetExcelVerticalAlignment(CellContentVerticalAlignment verticalAlignment)
-        {
-            return verticalAlignment switch
-            {
-                CellContentVerticalAlignment.Top => XLAlignmentVerticalValues.Top,
-                CellContentVerticalAlignment.Middle => XLAlignmentVerticalValues.Center,
-                CellContentVerticalAlignment.Bottom => XLAlignmentVerticalValues.Bottom,
-                _ => throw new NotImplementedException(verticalAlignment.ToString())
-            };
-        }
-
-        private XLAlignmentHorizontalValues GetExcelHorizontalAlignment(CellContentHorizontalAlignment horizontalAlignment) =>
-            horizontalAlignment switch
-            {
-                CellContentHorizontalAlignment.Center => XLAlignmentHorizontalValues.Center,
-                CellContentHorizontalAlignment.Left => XLAlignmentHorizontalValues.Left,
-                CellContentHorizontalAlignment.Right => XLAlignmentHorizontalValues.Right,
-                _ => throw new NotImplementedException(horizontalAlignment.ToString())
-            };
-
-        private XLBorderStyleValues GetExcelBorderStyle(CellBorderType borderType) =>
-            borderType switch
-            {
-                CellBorderType.Hidden => XLBorderStyleValues.None,
-                CellBorderType.Bold => XLBorderStyleValues.Medium,
-                CellBorderType.Thin => XLBorderStyleValues.Thin,
-                _ => throw new NotImplementedException(borderType.ToString())
-            };
+        // Определение dpi через Graphics не рабатает (не находит сборку System.Drawing.Common).
+        var hwnd = GetDesktopWindow();
+        var hMonitor = MonitorFromWindow(hwnd, 0);
+        GetDpiForMonitor(hMonitor, 0, out _dpiX, out _dpiY);
+        _isDpiCalculated = true;
     }
 }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/FromExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/FromExcelTableConverter.cs
@@ -1,48 +1,60 @@
-﻿namespace RxBim.Tools.TableBuilder
+﻿namespace RxBim.Tools.TableBuilder;
+
+using System.Collections.Generic;
+using System.Linq;
+using ClosedXML.Excel;
+using ClosedXML.Excel.Drawings;
+using JetBrains.Annotations;
+
+/// <summary>
+/// Represents a <see cref="Table"/> converter from an Excel workbook.
+/// </summary>
+[UsedImplicitly]
+internal class FromExcelTableConverter : IFromExcelTableConverter
 {
-    using System.Linq;
-    using ClosedXML.Excel;
-    using JetBrains.Annotations;
-
-    /// <summary>
-    /// Represents a <see cref="Table"/> converter from an Excel workbook.
-    /// </summary>
-    [UsedImplicitly]
-    internal class FromExcelTableConverter : IFromExcelTableConverter
+    /// <inheritdoc/>
+    public Table Convert(IXLWorkbook workbook, FromExcelConverterParameters parameters)
     {
-        /// <inheritdoc/>
-        public Table Convert(IXLWorkbook source, FromExcelConverterParameters parameters)
+        var sheet = string.IsNullOrWhiteSpace(parameters.WorksheetName)
+            ? workbook.Worksheet(1)
+            : workbook.Worksheet(parameters.WorksheetName);
+
+        var tableBuilder = new TableBuilder();
+
+        var tableRowIndex = 0;
+        var rowsCount = sheet.Rows().Count();
+        var columnsCount = sheet.Columns().Count();
+        var xlPictures = GetPictures(sheet);
+
+        tableBuilder.AddColumn(count: columnsCount);
+
+        // Read data
+        for (var sourceRowIndex = 1; sourceRowIndex <= rowsCount; sourceRowIndex++)
         {
-            var sheet = string.IsNullOrWhiteSpace(parameters.WorksheetName)
-                ? source.Worksheet(1)
-                : source.Worksheet(parameters.WorksheetName);
+            var xlRow = sheet.Row(sourceRowIndex);
+            tableBuilder.AddRow();
 
-            var builder = new TableBuilder();
-
-            var tableRowIndex = 0;
-            var rowsCount = sheet.Rows().Count();
-            var columnsCount = sheet.Columns().Count();
-
-            builder.AddColumn(count: columnsCount);
-
-            // Read data
-            for (var sourceRowIndex = 1; sourceRowIndex <= rowsCount; sourceRowIndex++)
+            var tableColumnIndex = 0;
+            for (var sourceColumnIndex = 1; sourceColumnIndex <= columnsCount; sourceColumnIndex++)
             {
-                var row = sheet.Row(sourceRowIndex);
-                builder.AddRow();
+                var xlCell = xlRow.Cell(sourceColumnIndex);
+                var cellBuilder = tableBuilder[tableRowIndex, tableColumnIndex];
 
-                var tableColumnIndex = 0;
-                for (var sourceColumnIndex = 1; sourceColumnIndex <= columnsCount; sourceColumnIndex++)
-                {
-                    var cellValue = row.Cell(sourceColumnIndex).Value;
-                    builder[tableRowIndex, tableColumnIndex].SetValue(cellValue);
-                    tableColumnIndex++;
-                }
+                if (xlPictures.TryGetValue(xlCell, out var xlPicture))
+                    cellBuilder.SetContent(new ImageCellContent(xlPicture.ImageStream.ToArray(), xlCell.Value));
+                else
+                    xlCell.SetValue(xlCell.Value);
 
-                tableRowIndex++;
+                tableColumnIndex++;
             }
 
-            return builder;
+            tableRowIndex++;
         }
+
+        return tableBuilder;
     }
+
+    private Dictionary<IXLCell, IXLPicture> GetPictures(IXLWorksheet sheet) => sheet.Pictures
+        .GroupBy(p => p.TopLeftCell)
+        .ToDictionary(k => k.Key, v => v.First());
 }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Extensions/ExcelExtensions.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Extensions/ExcelExtensions.cs
@@ -1,0 +1,84 @@
+﻿namespace RxBim.Tools.TableBuilder;
+
+using System;
+using System.Runtime.InteropServices;
+
+/// <summary>
+/// Extensions for Excel.
+/// </summary>
+public static class ExcelExtensions
+{
+    /// <summary>
+    /// Standard DPI.
+    /// </summary>
+    private const int StandardDpi = 96;
+
+    /// <summary>
+    /// Is DPI calculated.
+    /// </summary>
+    private static bool _isDpiCalculated;
+
+    /// <summary>
+    /// DPI by X.
+    /// </summary>
+    private static uint _dpiX;
+
+    /// <summary>
+    /// DPI by Y.
+    /// </summary>
+    private static uint _dpiY;
+
+    /// <summary>
+    /// Returns the width in pixels.
+    /// </summary>
+    /// <param name="width">Width in Excel points.</param>
+    public static double ExcelWidthToPixels(this double width)
+    {
+        // DPI (screen resolution) is used to determine the width and height of Excel in pixels.
+        CalculateDpi();
+
+        // Magic constants for determining column width and row height in pixels (from Google).
+        // https://github.com/ClosedXML/ClosedXML/issues/846
+        return (width * 7 + 12) / ((double)StandardDpi / _dpiX);
+    }
+
+    /// <summary>
+    /// Returns the height in pixels.
+    /// </summary>
+    /// <param name="height">Height in Excel points.</param>
+    public static double ExcelHeightToPixels(this double height)
+    {
+        CalculateDpi();
+
+        // https://learn.microsoft.com/en-us/answers/questions/257675/excel-row-height-logic-calculation
+        return height / 0.75 / ((double)StandardDpi / _dpiY);
+    }
+
+    [DllImport("shcore.dll")]
+    private static extern int GetDpiForMonitor(IntPtr hmonitor, int dpiType, out uint dpiX, out uint dpiY);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetDesktopWindow();
+
+    private static void CalculateDpi()
+    {
+        if (_isDpiCalculated)
+            return;
+
+        // Determining dpi via Graphics does not work (does not find the System.Drawing.Common assembly).
+        var hwnd = GetDesktopWindow();
+        var hMonitor = MonitorFromWindow(hwnd, 0);
+        GetDpiForMonitor(hMonitor, 0, out _dpiX, out _dpiY);
+
+        if (_dpiX == 0)
+            _dpiX = StandardDpi;
+
+        if (_dpiY == 0)
+            _dpiY = StandardDpi;
+
+        _isDpiCalculated = true;
+    }
+}

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/RxBim.Tools.TableBuilder.Excel.csproj
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/RxBim.Tools.TableBuilder.Excel.csproj
@@ -16,6 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Core\RxBim.Tools.TableBuilder\RxBim.Tools.TableBuilder.csproj" />
-  </ItemGroup>  
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
В общую часть TableBuilder добавлен тип контента для ячейки ImageCellContent, с картинкой в виде Stream.
Пока используется только в Excel.
В Excel возникли сложности с выравниванием картинки. Нужно задать отступы картинки в пикселях. Ширина столбца и высота строки - имеют разные размерности. Нашел какие-то коэффициенты преобразования их в пиксели. И зависимость от разрешения экрана. Но с использованием страшного вин апи (

Добавил пример использования в RxBim.Tools.TableBuilder.Excel.Sample.

<img src="https://github.com/user-attachments/assets/2b8e59cd-0cea-470e-ba41-aef1b8cfa772" width=50% height=50%>

