### PR TITLE
Обновил ClosedXML

### DIFF
--- a/.idea/.idea.RxBim.Tools/.idea/projectSettingsUpdater.xml
+++ b/.idea/.idea.RxBim.Tools/.idea/projectSettingsUpdater.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="RiderProjectSettingsUpdater">
     <option name="singleClickDiffPreview" value="1" />
+    <option name="unhandledExceptionsIgnoreList" value="1" />
     <option name="vcsConfiguration" value="3" />
   </component>
 </project>

--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -6,6 +6,7 @@
         <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
         <NoWarn>NU1901;NU1902;NU1903;NU1904</NoWarn>
+        <RxBimVersion>3.0.5-dev001</RxBimVersion>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -34,7 +35,7 @@
     </Choose>
 
     <ItemGroup>
-        <PackageReference Condition=" '$(UseDi)' == 'true' " Include="RxBim.Di" Version="3.0.5-dev001"/>
+        <PackageReference Condition=" '$(UseDi)' == 'true' " Include="RxBim.Di" Version="$(RxBimVersion)"/>
     </ItemGroup>
 
     <Choose>

--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-        <Version>4.0.5-dev002</Version>
+        <Version>4.0.6-lc006</Version>
         <TargetFramework>net472</TargetFramework>
         <PlatformTarget>x64</PlatformTarget>
         <LangVersion>12</LangVersion>

--- a/samples/RxBim.Command.TableBuilder.Autocad.Sample/RxBim.Command.TableBuilder.Autocad.Sample.csproj
+++ b/samples/RxBim.Command.TableBuilder.Autocad.Sample/RxBim.Command.TableBuilder.Autocad.Sample.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <UseDi>true</UseDi>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="..\..\src\Autocad\RxBim.Tools.Autocad\RxBim.Tools.Autocad.csproj" />
         <ProjectReference Include="..\..\src\Autocad\RxBim.Tools.TableBuilder.Autocad\RxBim.Tools.TableBuilder.Autocad.csproj" />
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.34.3" />
-        <PackageReference Include="RxBim.Command.Autocad.$(ApplicationVersion)" Version="3.0.0" />
+        <PackageReference Include="RxBim.Command.Autocad.$(ApplicationVersion)" Version="$(RxBimVersion)" />
     </ItemGroup>
 
 </Project>

--- a/samples/RxBim.Command.TableBuilder.Revit.Sample/RxBim.Command.TableBuilder.Revit.Sample.csproj
+++ b/samples/RxBim.Command.TableBuilder.Revit.Sample/RxBim.Command.TableBuilder.Revit.Sample.csproj
@@ -3,9 +3,9 @@
     <PropertyGroup>
         <UseDi>true</UseDi>
     </PropertyGroup>
-    
+
     <ItemGroup>
-        <PackageReference Include="RxBim.Command.Revit.$(ApplicationVersion)" Version="3.0.0" />
+        <PackageReference Include="RxBim.Command.Revit.$(ApplicationVersion)" Version="$(RxBimVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/RxBim.Tools.Autocad.Sample/RxBim.Tools.Autocad.Sample.csproj
+++ b/samples/RxBim.Tools.Autocad.Sample/RxBim.Tools.Autocad.Sample.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
       <PackageReference Remove="JetBrains.Annotations" />
-      <PackageReference Include="RxBim.Command.Autocad.$(ApplicationVersion)" Version="3.0.0" />
+      <PackageReference Include="RxBim.Command.Autocad.$(ApplicationVersion)" Version="$(RxBimVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/RxBim.Tools.LogStorage.Revit.Sample/RxBim.Tools.LogStorage.Revit.Sample.csproj
+++ b/samples/RxBim.Tools.LogStorage.Revit.Sample/RxBim.Tools.LogStorage.Revit.Sample.csproj
@@ -3,14 +3,14 @@
     <PropertyGroup>
         <UseDi>true</UseDi>
     </PropertyGroup>
-    
+
     <ItemGroup>
-        <PackageReference Include="RxBim.Command.Revit.$(ApplicationVersion)" Version="3.0.0" />
+        <PackageReference Include="RxBim.Command.Revit.$(ApplicationVersion)" Version="$(RxBimVersion)" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\Revit\RxBim.Tools.Revit\RxBim.Tools.Revit.csproj" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <None Update="appsettings.RxBim.Sample.Command.Revit.json">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/samples/RxBim.Tools.TableBuilder.Excel.Sample/RxBim.Tools.TableBuilder.Excel.Sample.csproj
+++ b/samples/RxBim.Tools.TableBuilder.Excel.Sample/RxBim.Tools.TableBuilder.Excel.Sample.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net8.0-windows</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <Nullable>enable</Nullable>
         <UseDi>true</UseDi>

--- a/samples/RxBim.Tools.TableBuilder.Excel.Sample/RxBim.Tools.TableBuilder.Excel.Sample.csproj
+++ b/samples/RxBim.Tools.TableBuilder.Excel.Sample/RxBim.Tools.TableBuilder.Excel.Sample.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net8.0-windows</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <Nullable>enable</Nullable>
-        <UseDi>true</UseDi>                
+        <UseDi>true</UseDi>
     </PropertyGroup>
     
     <ItemGroup>

--- a/src/Core/RxBim.Tools.TableBuilder/Extensions/ArrayExtensions.cs
+++ b/src/Core/RxBim.Tools.TableBuilder/Extensions/ArrayExtensions.cs
@@ -14,9 +14,9 @@ public static class ArrayExtensions
     /// <param name="action">Iterator action.</param>
     public static void ForEach(this Array array, Action<Array, int[]> action)
     {
-        if (array.LongLength == 0) 
+        if (array.LongLength == 0)
             return;
-        
+
         var walker = new ArrayTraverse(array);
         do
             action(array, walker.Position);
@@ -29,7 +29,7 @@ internal class ArrayTraverse
 #pragma warning restore SA1600,SA1402
 {
     private readonly int[] _maxLengths;
-    
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ArrayTraverse"/> class.
     /// </summary>
@@ -39,10 +39,10 @@ internal class ArrayTraverse
         _maxLengths = new int[array.Rank];
         for (var i = 0; i < array.Rank; ++i)
             _maxLengths[i] = array.GetLength(i) - 1;
-        
+
         Position = new int[array.Rank];
     }
-    
+
     /// <summary>
     /// Items positions.
     /// </summary>
@@ -57,15 +57,15 @@ internal class ArrayTraverse
         {
             if (Position[i] >= _maxLengths[i])
                 continue;
-            
+
             Position[i]++;
-            
+
             for (var j = 0; j < i; j++)
                 Position[j] = 0;
-                
+
             return true;
         }
-        
+
         return false;
     }
 }

--- a/src/Core/RxBim.Tools.TableBuilder/RxBim.Tools.TableBuilder.csproj
+++ b/src/Core/RxBim.Tools.TableBuilder/RxBim.Tools.TableBuilder.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <Description>RxBim table builder Library</Description>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>

--- a/src/Core/RxBim.Tools.TableBuilder/Services/TableBuilder.cs
+++ b/src/Core/RxBim.Tools.TableBuilder/Services/TableBuilder.cs
@@ -111,13 +111,13 @@ public class TableBuilder : ITableBuilder
 
         if (RowsCount <= headerRowsCount + 1)
             return this;
-            
+
         SetCellsFormat(rowFormat,
             headerRowsCount + 1,
             0,
             ColumnsCount,
             RowsCount - headerRowsCount);
-            
+
         foreach (var cell in Table.Rows.Last().Cells)
             new CellEditor(cell).SetFormat(lastRowFormat);
 
@@ -176,7 +176,7 @@ public class TableBuilder : ITableBuilder
             for (var r = 0; r < list.Count; r++)
             {
                 var value = prop.Invoke(list[r]);
-                matrix[r, c] = prop as ICellContent ?? new TextCellContent(value.ToString());
+                matrix[r, c] = value as ICellContent ?? new TextCellContent(value.ToString());
             }
         }
 

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
@@ -127,7 +127,7 @@ internal class ExcelTableConverter : IExcelTableConverter
                 break;
 
             case NumericCellContent numeric:
-                cell.Value = XLCellValue.FromObject(numeric.ValueObject);
+                cell.Value = numeric.ValueObject.FromObject();
                 cell.Style.NumberFormat.Format = numeric.Format;
                 break;
 
@@ -136,7 +136,7 @@ internal class ExcelTableConverter : IExcelTableConverter
                 break;
 
             default:
-                cell.SetValue(content.ValueObject?.ToString());
+                cell.Value = content.ValueObject.FromObject();
                 break;
         }
     }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/ExcelTableConverter.cs
@@ -127,7 +127,7 @@ internal class ExcelTableConverter : IExcelTableConverter
                 break;
 
             case NumericCellContent numeric:
-                cell.Value = numeric.ValueObject;
+                cell.Value = XLCellValue.FromObject(numeric.ValueObject);
                 cell.Style.NumberFormat.Format = numeric.Format;
                 break;
 
@@ -136,7 +136,7 @@ internal class ExcelTableConverter : IExcelTableConverter
                 break;
 
             default:
-                cell.SetValue(content.ValueObject);
+                cell.SetValue(content.ValueObject?.ToString());
                 break;
         }
     }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/FromExcelTableConverter.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Converters/FromExcelTableConverter.cs
@@ -43,7 +43,7 @@ internal class FromExcelTableConverter : IFromExcelTableConverter
                 if (xlPictures.TryGetValue(xlCell, out var xlPicture))
                     cellBuilder.SetContent(new ImageCellContent(xlPicture.ImageStream.ToArray(), xlCell.Value));
                 else
-                    cellBuilder.SetValue(xlCell.Value);
+                    cellBuilder.SetValue(xlCell.GetValueAsObject());
 
                 tableColumnIndex++;
             }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Extensions/XlCellExtensions.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Extensions/XlCellExtensions.cs
@@ -23,4 +23,28 @@ public static class XlCellExtensions
         XLDataType.Blank => string.Empty,
         _ => cell.Value
     };
+
+    /// <summary>
+    /// Возвращает значение ячейки.
+    /// </summary>
+    /// <param name="value">Значение.</param>
+    public static XLCellValue FromObject(this object? value) => value switch
+    {
+        byte b => b,
+        sbyte sb => sb,
+        short s => s,
+        ushort us => us,
+        int i => i,
+        uint ui => ui,
+        long l => l,
+        ulong ul => ul,
+        float f => f,
+        double d => d,
+        decimal m => m,
+        bool bl => bl,
+        DateTime dt => dt,
+        TimeSpan ts => ts,
+        string s => s,
+        _ => Blank.Value
+    };
 }

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/Extensions/XlCellExtensions.cs
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/Extensions/XlCellExtensions.cs
@@ -1,0 +1,26 @@
+﻿namespace RxBim.Tools.TableBuilder;
+
+using System;
+using ClosedXML.Excel;
+
+/// <summary>
+/// Расширения для ячейки <see cref="IXLCell"/>.
+/// </summary>
+public static class XlCellExtensions
+{
+    /// <summary>
+    /// Возвращает значение ячейки как объект.
+    /// </summary>
+    /// <param name="cell">Ячейка.</param>
+    public static object GetValueAsObject(this IXLCell cell) => cell.DataType switch
+    {
+        XLDataType.Number => cell.GetValue<double>(),
+        XLDataType.Text => cell.GetValue<string>(),
+        XLDataType.Boolean => cell.GetValue<bool>(),
+        XLDataType.DateTime => cell.GetValue<DateTime>(),
+        XLDataType.TimeSpan => cell.GetValue<TimeSpan>(),
+        XLDataType.Error => cell.GetValue<XLError>(),
+        XLDataType.Blank => string.Empty,
+        _ => cell.Value
+    };
+}

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/RxBim.Tools.TableBuilder.Excel.csproj
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/RxBim.Tools.TableBuilder.Excel.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.105.0" />
+    <PackageReference Include="ClosedXML" Version="0.100.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Excel/RxBim.Tools.TableBuilder.Excel/RxBim.Tools.TableBuilder.Excel.csproj
+++ b/src/Excel/RxBim.Tools.TableBuilder.Excel/RxBim.Tools.TableBuilder.Excel.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.96.0" />
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Обновление closedxml - для совместимости с Autocad 2025 (он грузит из своей папки 0.100.3, которая конфликтует с нашей 0.96). 

Со значениями в ячейках какая-то новая штука у них Generic только. Значение ячейки это тип XLCellValue.  
Как раньше object значения нет ( Странно.  
Задать значение в ячейку для большинства типов как обычно cell.Value = 5, срабатывает штатная конвертация implicit и есть метод для object:  
cell.Value = XLCellValue.FromObject(object);

Получить значение тоже через Generic - cell.GetValue<T>  
Добавил расширение GetValueAsObject.


## Общие изменения:  
RxBimVersion добавил версию, для ссылки в примерах. А то там старые версии пакетов подключались (